### PR TITLE
マテリアルテーマのバグ修正

### DIFF
--- a/browser/themes/shared/browser.inc.css
+++ b/browser/themes/shared/browser.inc.css
@@ -1352,6 +1352,20 @@ hbox[anonid="findbar-textbox-wrapper"] toolbarbutton:not([disabled]):hover:activ
 	height: auto !important;
 }
 
+#tabbrowser-arrowscrollbox::part(scrollbutton-up), #tabbrowser-arrowscrollbox::part(scrollbutton-down) {
+    width: 32px !important;
+    height: 32px !important;
+    border-radius: 99px !important;
+    margin: 0 !important;
+    margin-top: calc(var(--tab-shadow-max-size) + 3px) !important;
+    margin-bottom: 1px !important;
+    padding: 0 !important;
+    border: 2px solid transparent !important;
+    transition-property: background-color, background-size, fill-opacity !important;
+    transition-duration: .3s !important;
+    transition-timing-function: var(--ease-basic), var(--ease-out), var(--ease-basic) !important;
+}
+
 /*
 	hack: fix customization screen popping bug when changing ui density
 	icon size is enforced and it doesn't like it when the normal density

--- a/browser/themes/shared/tabs.inc.css
+++ b/browser/themes/shared/tabs.inc.css
@@ -585,7 +585,9 @@
 #tabbrowser-tabs::part(arrowscrollbox-overflow-end-indicator),
 /* no ::part workaround - may have side effects */
 spacer[part="overflow-start-indicator"],
-spacer[part="overflow-end-indicator"]
+spacer[part="overflow-end-indicator"],
+#tabbrowser-arrowscrollbox::part(overflow-start-indicator),
+#tabbrowser-arrowscrollbox::part(overflow-end-indicator)
 {
 	display: none !important;
 }

--- a/browser/themes/shared/tabs.inc.css
+++ b/browser/themes/shared/tabs.inc.css
@@ -279,6 +279,7 @@
 	bottom: 0 !important;
 	pointer-events: none !important;
 	transition: box-shadow 0s var(--tab-transition-duration) var(--ease-basic) !important;
+  clip-path: inset(0) !important;
 }
 
 .tab-background::before


### PR DESCRIPTION
### タブの背景色に透明度のあるテーマを使用した時に白い四角が表示されるバグを修正
Before
![スクリーンショット 2022-02-23 022035](https://user-images.githubusercontent.com/59644555/155184796-da6bdab9-6cc3-4c8f-84ed-3bc0daee0a01.png)
After
![スクリーンショット 2022-02-23 021627](https://user-images.githubusercontent.com/59644555/155184849-b947d4e2-8b40-4ceb-a62f-81a4297e0370.png)

### タブのスクロールボタンがProton UIになっているバグを修正
Before
![スクリーンショット 2022-02-23 022123](https://user-images.githubusercontent.com/59644555/155185061-ed82195f-2369-4416-96b4-5b48e89dcfc8.png)
After
![スクリーンショット 2022-02-23 021533](https://user-images.githubusercontent.com/59644555/155185088-1a2d7bb8-239d-4b0b-b7b9-8a1bcb97b248.png)

